### PR TITLE
feat: add react-native-reanimated carousel and style product display page

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
+  plugins: ['react-native-worklets/plugin']
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mockStore",
+  "name": "mock-store",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mockStore",
+      "name": "mock-store",
       "version": "0.0.1",
       "dependencies": {
         "@react-native-vector-icons/ionicons": "^12.3.0",
@@ -19,9 +19,13 @@
         "lint-staged": "^16.1.6",
         "react": "19.1.0",
         "react-native": "0.81.4",
+        "react-native-gesture-handler": "^2.28.0",
         "react-native-linear-gradient": "^2.8.3",
+        "react-native-reanimated": "^4.1.2",
+        "react-native-reanimated-carousel": "^4.0.3",
         "react-native-safe-area-context": "^5.5.2",
         "react-native-screens": "^4.16.0",
+        "react-native-worklets": "^0.6.0",
         "react-redux": "^9.2.0",
         "tsc-files": "^1.1.4"
       },
@@ -141,7 +145,6 @@
       "version": "7.27.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
       "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.27.3"
@@ -170,7 +173,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
       "integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -192,7 +194,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
       "integrity": "sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
@@ -236,7 +237,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
       "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -280,7 +280,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
       "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.27.1"
@@ -320,7 +319,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
       "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.27.1",
@@ -338,7 +336,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
       "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -686,7 +683,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
       "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -804,7 +800,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
       "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -837,7 +832,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
       "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -921,7 +915,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
       "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.27.1",
@@ -955,7 +948,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz",
       "integrity": "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -1258,7 +1250,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
       "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -1344,7 +1335,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
       "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1429,7 +1419,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
       "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1651,7 +1640,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
       "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1700,7 +1688,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1732,7 +1719,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
       "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -1785,7 +1771,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
       "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1915,6 +1900,25 @@
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
@@ -1994,6 +1998,18 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -3645,6 +3661,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -7320,6 +7342,21 @@
       "dependencies": {
         "hermes-estree": "0.29.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -11017,6 +11054,21 @@
         }
       }
     },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
+      "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
@@ -11035,6 +11087,46 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-reanimated": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.2.tgz",
+      "integrity": "sha512-qzmQiFrvjm62pRBcj97QI9Xckc3EjgHQoY1F2yjktd0kpjhoyePeuTEXjYRCAVIy7IV/1cfeSup34+zFThFoHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1",
+        "semver": "7.7.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-worklets": ">=0.5.0"
+      }
+    },
+    "node_modules/react-native-reanimated-carousel": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated-carousel/-/react-native-reanimated-carousel-4.0.3.tgz",
+      "integrity": "sha512-YZXlvZNghR5shFcI9hTA7h7bEhh97pfUSLZvLBAshpbkuYwJDKmQXejO/199T6hqGq0wCRwR0CWf2P4Vs6A4Fw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-native": ">=0.70.3",
+        "react-native-gesture-handler": ">=2.9.0",
+        "react-native-reanimated": ">=3.0.0"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -11060,6 +11152,42 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.6.0.tgz",
+      "integrity": "sha512-yETMNuCcivdYWteuG4eRqgiAk2DzRCrVAaEBIEWPo4emrf3BNjadFo85L5QvyEusrX9QKE3ZEAx8U5A/nbyFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "semver": "7.7.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/commander": {
@@ -11193,14 +11321,12 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
       "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
       "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2"
@@ -11240,7 +11366,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.3.1.tgz",
       "integrity": "sha512-DzcswPr252wEr7Qz8AyAVbfyBDKLoYp6eRA1We2Fa9qirRFSdtkP5sHr3yglDKy2BbA0fd2T+j/CUSKes3FeVQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2",
@@ -11258,14 +11383,12 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
       "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/regjsparser": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
       "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
-      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~3.0.2"
@@ -11278,7 +11401,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
       "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -12576,7 +12698,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
       "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -12586,7 +12707,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
       "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "unicode-canonical-property-names-ecmascript": "^2.0.0",
@@ -12600,7 +12720,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
       "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -12610,7 +12729,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
       "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -22,9 +22,13 @@
     "lint-staged": "^16.1.6",
     "react": "19.1.0",
     "react-native": "0.81.4",
+    "react-native-gesture-handler": "^2.28.0",
     "react-native-linear-gradient": "^2.8.3",
+    "react-native-reanimated": "^4.1.2",
+    "react-native-reanimated-carousel": "^4.0.3",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.16.0",
+    "react-native-worklets": "^0.6.0",
     "react-redux": "^9.2.0",
     "tsc-files": "^1.1.4"
   },

--- a/src/components/GradientWrapper.tsx
+++ b/src/components/GradientWrapper.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import LinearGradient from 'react-native-linear-gradient';
 import { MainStyles } from '../styles/MainStyles';
+import { ViewStyle } from 'react-native';
 
 interface GradientWrapperProps {
   children: React.ReactNode;
   fromColor?: string;
   toColor?: string;
+  containerStyle?: ViewStyle;
 }
 
 export const GradientWrapper = (props: GradientWrapperProps) => {
   const fColor = props.fromColor || '#00008B';
   const tColor = props.toColor || '#6e70f3ff'
   return (
-    <LinearGradient style={MainStyles.main} colors={[fColor, tColor]}>
+    <LinearGradient style={[MainStyles.main, props.containerStyle]} colors={[fColor, tColor]}>
       {props.children}
     </LinearGradient>
   );

--- a/src/components/PDP/ImageCarousel.tsx
+++ b/src/components/PDP/ImageCarousel.tsx
@@ -1,0 +1,41 @@
+import { Image, Text, View } from "react-native";
+import Carousel from "react-native-reanimated-carousel";
+import { styles } from "../../styles/ImageCarousel";
+ 
+interface ImageCarouselProps {
+  images?: string[];
+}
+
+export const ImageCarousel: React.FC<ImageCarouselProps> = ({images}) => {
+  const renderItem = (item: any) => {
+    return (
+      <View>
+        <Image source={{ uri: item.item }} resizeMode='contain' style={styles.image} />
+      </View>
+    );
+  }
+
+  if (!images?.length) {
+    return (
+      <View style={[styles.carousel, styles.noImages]}>
+        <Text style={styles.noImagesText}>Image not available</Text>
+      </View>
+    );
+  }
+
+	return (
+		<View id="carousel-component">
+			<Carousel
+				testID={"image-carousel"}
+				loop={false}
+				width={250}
+				height={250}
+				snapEnabled={true}
+				pagingEnabled={false}
+				data={images}
+				style={styles.carousel}
+				renderItem={renderItem}
+			/>
+		</View>
+	);
+}

--- a/src/components/PDP/PDPDetails.tsx
+++ b/src/components/PDP/PDPDetails.tsx
@@ -1,0 +1,29 @@
+import { Text, TouchableOpacity, View } from 'react-native';
+import { useState } from 'react';
+import { styles } from '../../styles/PDPDetails';
+import Ionicons from '@react-native-vector-icons/ionicons';
+
+interface PDPDetailsProps {
+  title: string;
+  text: string;
+}
+
+export const PDPDetails: React.FC<PDPDetailsProps> = ({ title, text }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleIsOpen = () => {
+    setIsOpen(!isOpen);
+  }
+
+  return (
+    <TouchableOpacity onPress={toggleIsOpen} style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerText}>{title}</Text>
+        <Ionicons name={isOpen ? 'chevron-up' : 'chevron-down'} size={20} />
+      </View>
+      {isOpen && (
+        <Text style={styles.descriptionText}>{text}</Text>
+      )}
+    </TouchableOpacity>
+  );
+}

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,0 +1,67 @@
+import { Product, ProductDetail } from "../types/product";
+
+export const formatPDPDetails = (product?: Product) => {
+  const productData: ProductDetail[] = [];
+  if (!product) {
+    return [];
+  }
+
+  Object.keys(product).forEach(key => {
+    switch(key) {
+      case 'brand':
+        if (product.brand) {
+          productData.push({
+            title: 'Brand',
+            text: product.brand
+          });
+        }
+        break;
+      case 'dimensions':
+        const width = product.dimensions?.width;
+        const height = product.dimensions?.height;
+        const depth = product.dimensions?.depth;
+        let dimensionString = '';
+        if (!!width) {
+          dimensionString += `Width: ${width} `;
+        }
+        if (!!height) {
+          dimensionString += `Height: ${height} `;
+        }
+        if (!!depth) {
+          dimensionString += `Depth: ${depth}`;
+        }
+        if (!!dimensionString) {
+          productData.push({
+            title: 'Dimensions',
+            text: dimensionString
+          });
+        }
+        break; 
+      case 'returnPolicy':
+        if (product.returnPolicy) {
+          productData.push({
+            title: 'Return Policy',
+            text: product.returnPolicy
+          });
+        }
+        break;
+      case 'shippingInformation':
+        if (product.shippingInformation) {
+          productData.push({
+            title: 'Shipping Information',
+            text: product.shippingInformation
+          });
+        }
+        break;
+      case 'warrantyInformation':
+        if (product.warrantyInformation) {
+          productData.push({
+            title: 'Warranty Information',
+            text: product.warrantyInformation
+          })
+        }
+        break;
+    }
+  });
+  return productData;
+}

--- a/src/reducers/productData.ts
+++ b/src/reducers/productData.ts
@@ -8,7 +8,7 @@ export const productApi = createApi({
     getProductsFromCategory: build.query<Products, string>({
       query: (categorySlug) => `products/category/${categorySlug}`
     }),
-    getProduct: build.query<Product, number>({
+    getProduct: build.query<Product, string>({
       query: (id) => `products/${id}`
     })
   })

--- a/src/screens/ProductDisplay.tsx
+++ b/src/screens/ProductDisplay.tsx
@@ -1,10 +1,63 @@
-import { Text, View } from 'react-native';
-import { MainStyles } from '../styles/MainStyles';
+import { ActivityIndicator, ScrollView, Text, View } from 'react-native';
+import { RouteProp } from '@react-navigation/native';
+import { GradientWrapper } from '../components/GradientWrapper';
+import { useGetProductQuery } from '../reducers/productData';
+import { styles } from '../styles/ProductDisplay';
+import { ImageCarousel } from '../components/PDP/ImageCarousel';
+import { Product } from '../types/product';
+import { PDPDetails } from '../components/PDP/PDPDetails';
+import { formatPDPDetails } from '../lib/helpers';
 
-export const ProductDisplayScreen = () => {
+interface ProductDisplayProps {
+  route?: RouteProp<{ params: { productId: string } }, 'params'>;
+}
+
+
+
+export const ProductDisplayScreen: React.FC<ProductDisplayProps> = ({ route }) => {
+  const productId = route?.params?.productId || '';
+  // fyi, I know I don't need to make this request as all product data is sent with categories
+  // request. however, I wanted to add another rtk query request as other apis will be different
+  const { data, isLoading } = useGetProductQuery(productId);
+  console.log('pdp', data, isLoading);
+  const pdpDetails = formatPDPDetails(data);
+
   return (
-    <View style={MainStyles.main}>
-      <Text>PDP</Text>
-    </View>
+    <GradientWrapper>
+     {isLoading ? (
+        <View style={styles.loading}>
+          <ActivityIndicator size={'large'} />
+        </View>
+      ) : (
+        <ScrollView style={styles.container}>
+          {data ? (
+            <View style={styles.productBox}>
+              <View style={styles.productContainer}>
+                <View style={styles.carouselContainer}>
+                  <ImageCarousel images={data.images} />
+                </View>
+              </View>
+              <View style={styles.productInfo}>
+                <Text style={styles.productTitle}>{data.title}</Text>
+                <Text style={styles.productPrice}>${data.price}</Text>
+                <Text style={styles.productDescription}>{data.description}</Text>
+                {pdpDetails.length && (
+                  <View>
+                    <Text style={styles.productDetailsTitle}>Product Details</Text>
+                    {pdpDetails.map(detail => {
+                      return <PDPDetails title={detail.title} text={detail.text} key={detail.title}/>
+                    })}
+                  </View>
+                )}
+              </View>
+            </View>
+          ) : (
+            <View style={styles.loading}>
+              <Text style={styles.noProductsText}>Sorry, we were unable to load product data</Text>
+            </View>
+          )}
+        </ScrollView>
+      )}
+    </GradientWrapper>
   );
 }

--- a/src/styles/ImageCarousel.ts
+++ b/src/styles/ImageCarousel.ts
@@ -1,0 +1,21 @@
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+  image: {
+    width: '100%',
+    height: '100%'
+  },
+  carousel: {
+    width: 250,
+    height: 250,
+    justifyContent: 'center' 
+  },
+  noImages: {
+    backgroundColor: '#00008B'
+  },
+  noImagesText: {
+    textAlign: 'center',
+    fontSize: 18,
+    color: '#fff'
+  }
+})

--- a/src/styles/PDPDetails.ts
+++ b/src/styles/PDPDetails.ts
@@ -1,0 +1,21 @@
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+  container: {
+
+  },
+  header: {
+    borderTopWidth: 1,
+    borderTopColor: '#9e9e9aff',
+    paddingHorizontal: 10,
+    paddingVertical: 20,
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  headerText: {
+    fontSize: 14
+  },
+  descriptionText: {
+    padding: 20
+  }
+});

--- a/src/styles/ProductDisplay.ts
+++ b/src/styles/ProductDisplay.ts
@@ -1,0 +1,66 @@
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+  loading: {
+    width: '100%',
+    height: '100%',
+    justifyContent: 'center'
+  },
+  noProductsText: {
+    color: '#fff',
+    fontSize: 18,
+    textAlign: 'center'
+  },
+  container: {
+    height: '100%',
+    width: '100%',
+  },
+  productBox: {
+    marginBottom: 150
+  },
+  productContainer: {
+    marginTop: 30,
+    marginBottom: 10,
+    marginHorizontal: '10%',
+    width: '80%',
+    backgroundColor: '#fff',
+    borderRadius: 5
+  },
+  carouselContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    margin: 20,
+    borderWidth: 2,
+    borderRadius: 5
+  },
+  productInfo: {
+    marginHorizontal: '5%',
+    width: '90%',
+    borderRadius: 5,
+    backgroundColor: '#fff',
+    padding: 10
+  },
+  infoRow: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  productTitle: {
+    color: '#00008B',
+    fontSize: 18,
+    fontWeight: 'bold'
+  },
+  productPrice: {
+    fontSize: 16,
+    fontWeight: 'bold'
+  },
+  productDescription: {
+    marginTop: 10,
+    fontSize: 16
+  },
+  productDetailsTitle: {
+    fontSize: 18,
+    marginTop: 20,
+    marginBottom: 10
+  }
+});

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -50,3 +50,8 @@ export interface Review {
   reviewerName?:  string;
   reviewerEmail?: string;
 }
+
+export interface ProductDetail {
+  title: string;
+  text?: any;
+}


### PR DESCRIPTION
## Description

- adds react-native-reanimated-carousel for image carousel on pdp
- updates babel config for reanimated-carousel
- adds function to parse out pdp details
- adds component to display pdp details
- adds UI for pdp

## Dev Notes

- I do not really need to rtk query request for products as I could pass that data directly from the product list page, however, in the past these were different requests so I wanted both in the app

## Testing

1. click on Furniture category from Home screen
2. click on office chair
3. should navigate to product display page
4. should be able to scroll images in image carousel
5. page should scroll
6. click on product detail should open to show information
7. clicking again should close that detail section

## Screenshots

<img width="391" height="866" alt="Pasted image (6)" src="https://github.com/user-attachments/assets/d1d9d6bf-53a9-4743-94b5-3a9b60c921ee" />
