### PR TITLE
feat: add cart-store reducer and add to cart button on PDP

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -32,12 +32,16 @@ function RootStack() {
       >
         <Tab.Screen name="Home" component={HomeScreenStack} />
         <Tab.Screen name="Scan" component={ScanScreenStack} />
-        <Tab.Screen name="Cart" component={CartScreenStack} />
+        <Tab.Screen name="Cart"
+          component={CartScreenStack}
+          options={{ tabBarBadgeStyle: { color: '#fff', backgroundColor: '#00008B'}}}
+        />
       </Tab.Navigator>
   );
 }
 
 export default function App() {
+
   return (
     <Provider store={store}>
       <NavigationContainer>

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -2,11 +2,13 @@ import { configureStore } from "@reduxjs/toolkit";
 import { setupListeners } from "@reduxjs/toolkit/query";
 import { productApi } from "../reducers/productData";
 import storeDataReducer from "../reducers/storeData";
+import cartDataReducer from '../reducers/cartData';
 
 export const store = configureStore({
   reducer: {
     storeData: storeDataReducer,
-    [productApi.reducerPath]: productApi.reducer
+    [productApi.reducerPath]: productApi.reducer,
+    cartData: cartDataReducer
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(productApi.middleware)
 });

--- a/src/reducers/cartData.ts
+++ b/src/reducers/cartData.ts
@@ -1,0 +1,70 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { CartProduct } from "../types/cartTypes/cartTypes";
+
+import {
+  AddProductToCart,
+  DecrementCartItemQty,
+  IncrementCartItemQty,
+  RemoveProductFromCart
+} from "../types/cartTypes/cartActions";
+
+interface CartState {
+  cartCount: number;
+  items: CartProduct[];
+}
+
+const initialCartState: CartState = {
+  cartCount: 0,
+  items: []
+};
+
+export const cartDataSlice = createSlice({
+  name: 'cart',
+  initialState: initialCartState,
+  reducers: {
+    addToCart: (state, action: PayloadAction<AddProductToCart>) => {
+      const cartProduct = { ...action.payload.product, qty: action.payload.qty };
+      let itemInCart = false;
+      state.items.forEach(item => {
+        if (item.id === cartProduct.id) {
+          itemInCart = true;
+          item.qty += action.payload.qty;
+        }
+      });
+      if (!itemInCart) {
+        state.items.push(cartProduct);
+      }
+      state.cartCount += action.payload.qty;
+    },
+    removeFromCart: (state, action: PayloadAction<RemoveProductFromCart>) => {
+      state.items.filter(item => { return item.id !== action.payload.productId });
+    },
+    incrementCartQty: (state, action: PayloadAction<IncrementCartItemQty>) => {
+      state.items.map(item => {
+        if (item.id === action.payload.productId) {
+          item.qty += 1;
+          state.cartCount += 1;
+        }
+        return item;
+      });
+    },
+    decrementCartQty: (state, action: PayloadAction<DecrementCartItemQty>) => {
+      state.items.map(item => {
+        if (item.id === action.payload.productId) {
+          item.qty -= 1;
+          state.cartCount -= 1;
+        }
+        return item;
+      });
+    }
+  }
+});
+
+export const {
+  addToCart,
+  removeFromCart,
+  incrementCartQty,
+  decrementCartQty
+} = cartDataSlice.actions;
+
+export default cartDataSlice.reducer;

--- a/src/reducers/storeData.ts
+++ b/src/reducers/storeData.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
-import axios, { AxiosError } from "axios";
+import axios from "axios";
 import { Category } from "../types/category";
 
 export const fetchCategories = createAsyncThunk(

--- a/src/screens/CartScreen.tsx
+++ b/src/screens/CartScreen.tsx
@@ -1,7 +1,18 @@
 import { Text, View } from 'react-native';
 import { MainStyles } from '../styles/MainStyles';
+import { useEffect } from 'react';
+import { useAppSelector } from '../app/hooks';
+import { useNavigation } from '@react-navigation/native';
 
 export const CartScreen = () => {
+  const cartCount = useAppSelector(state => state.cartData.cartCount);
+  const navigation = useNavigation();
+  useEffect(() => {
+    navigation.getParent()?.setOptions({
+      tabBarBadge: cartCount ? cartCount : undefined,
+    });
+  }, [navigation, cartCount]);
+
   return (
     <View style={MainStyles.main}>
       <Text>Cart</Text>

--- a/src/screens/ProductDisplay.tsx
+++ b/src/screens/ProductDisplay.tsx
@@ -1,26 +1,40 @@
-import { ActivityIndicator, ScrollView, Text, View } from 'react-native';
+import { ActivityIndicator, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { RouteProp } from '@react-navigation/native';
+import { useState } from 'react';
 import { GradientWrapper } from '../components/GradientWrapper';
 import { useGetProductQuery } from '../reducers/productData';
 import { styles } from '../styles/ProductDisplay';
 import { ImageCarousel } from '../components/PDP/ImageCarousel';
-import { Product } from '../types/product';
 import { PDPDetails } from '../components/PDP/PDPDetails';
 import { formatPDPDetails } from '../lib/helpers';
+import { useAppDispatch, useAppSelector } from '../app/hooks';
+import { addToCart } from '../reducers/cartData';
 
 interface ProductDisplayProps {
   route?: RouteProp<{ params: { productId: string } }, 'params'>;
 }
-
-
 
 export const ProductDisplayScreen: React.FC<ProductDisplayProps> = ({ route }) => {
   const productId = route?.params?.productId || '';
   // fyi, I know I don't need to make this request as all product data is sent with categories
   // request. however, I wanted to add another rtk query request as other apis will be different
   const { data, isLoading } = useGetProductQuery(productId);
-  console.log('pdp', data, isLoading);
   const pdpDetails = formatPDPDetails(data);
+  const dispatch = useAppDispatch();
+  const cart = useAppSelector(state => state.cartData);
+
+  const [showAddedToCartModal, setShowAddedToCartModal] = useState(false);
+
+  const addProductToCart = () => {
+    if (data) {
+      dispatch(addToCart({product: data, qty: 1}));
+      setShowAddedToCartModal(true);
+    }
+  }
+
+  const closeAddedToCartModal = () => {
+    setShowAddedToCartModal(false);
+  }
 
   return (
     <GradientWrapper>
@@ -50,6 +64,7 @@ export const ProductDisplayScreen: React.FC<ProductDisplayProps> = ({ route }) =
                   </View>
                 )}
               </View>
+
             </View>
           ) : (
             <View style={styles.loading}>
@@ -58,6 +73,18 @@ export const ProductDisplayScreen: React.FC<ProductDisplayProps> = ({ route }) =
           )}
         </ScrollView>
       )}
+      {showAddedToCartModal && (
+        <View style={styles.addedToCartModal}>
+          <Text style={styles.addedToCartModalText}>Item added to cart!</Text>
+          <TouchableOpacity onPress={closeAddedToCartModal} style={styles.closeModalBtn}>
+            <Text style={styles.closeModalBtnText}>Close</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+      {showAddedToCartModal && <View style={styles.modalBackdrop} />}
+      <TouchableOpacity onPress={addProductToCart} style={styles.addToCartBtn}>
+        <Text style={styles.addToCartText}>Add To Cart</Text>
+      </TouchableOpacity>
     </GradientWrapper>
   );
 }

--- a/src/stacks/CartStack.tsx
+++ b/src/stacks/CartStack.tsx
@@ -8,7 +8,7 @@ const CartStack = createNativeStackNavigator();
 const CartScreenStack = () => {
   return (
     <CartStack.Navigator>
-      <CartStack.Screen name="Cart" component={CartScreen} />
+      <CartStack.Screen name="CartScreen" component={CartScreen} />
       <CartStack.Screen name="Checkout" component={CheckoutScreen} />
     </CartStack.Navigator>
   );

--- a/src/styles/ProductDisplay.ts
+++ b/src/styles/ProductDisplay.ts
@@ -16,7 +16,7 @@ export const styles = StyleSheet.create({
     width: '100%',
   },
   productBox: {
-    marginBottom: 150
+    marginBottom: 100
   },
   productContainer: {
     marginTop: 30,
@@ -62,5 +62,62 @@ export const styles = StyleSheet.create({
     fontSize: 18,
     marginTop: 20,
     marginBottom: 10
+  },
+  addToCartBtn: {
+    position: 'absolute',
+    width: '98%',
+    height: 60,
+    backgroundColor: '#00008B',
+    margin: '1%',
+    marginBottom: 5,
+    borderRadius: 5,
+    borderWidth: 2,
+    borderColor: '#00008B',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  addToCartText: {
+    color: '#fff',
+    fontSize: 24,
+    textAlign: 'center'
+  },
+  addedToCartModal: {
+    zIndex: 6,
+    position: 'absolute',
+    marginTop: '30%',
+    marginHorizontal: '20%',
+    width: '60%',
+    height: 200,
+    backgroundColor: '#fff',
+    padding: 20,
+    borderRadius: 20,
+    justifyContent: 'space-around'
+  },
+  addedToCartModalText: {
+    fontSize: 24,
+    textAlign: 'center',
+    fontWeight: 'bold'
+  },
+  closeModalBtn: {
+    width: '100%',
+    backgroundColor: '#00008B',
+    borderRadius: 5
+  },
+  closeModalBtnText: {
+    color: '#fff',
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10
+  },
+  modalBackdrop: {
+    zIndex: 5,
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+    backgroundColor: '#000',
+    opacity: 0.5
   }
 });

--- a/src/types/cartTypes/cartActions.ts
+++ b/src/types/cartTypes/cartActions.ts
@@ -1,0 +1,18 @@
+import { Product } from "../product";
+
+export interface AddProductToCart {
+  product: Product;
+  qty: number;
+}
+
+export interface RemoveProductFromCart {
+  productId: number;
+}
+
+export interface IncrementCartItemQty {
+  productId: number;
+}
+
+export interface DecrementCartItemQty {
+  productId: number;
+}

--- a/src/types/cartTypes/cartTypes.ts
+++ b/src/types/cartTypes/cartTypes.ts
@@ -1,0 +1,5 @@
+import { Product } from "../product";
+
+export interface CartProduct extends Product {
+  qty: number;
+}


### PR DESCRIPTION
## Description

- adds cart reducer
- adds add to cart button and functionality on pdp
- adds added to cart modal on pdp
- adds cart count badge to cart tab icon

## Dev Notes

- not able to get the cart count badge to show without first navigating to cart
-- tried moving setting cart count to App.tsx but that failed due to hook
-- tried moving setting cart count to Home screen but that added the badge to Home tab
-- I'm guessing the cart screen is not mounted until it is navigated to, which is preventing useEffect hook from firing

## Testing

1. click on category from home screen
2. click on product
3. on PDP, click Add To Cart button
4. should see Added to Cart modal
5. click to close modal
6. product should be added to cart in redux

## Screenshots


<img width="391" height="866" alt="Pasted image (8)" src="https://github.com/user-attachments/assets/d9882c05-61e1-481d-a390-162f55b9e525" />


<img width="391" height="866" alt="Pasted image (7)" src="https://github.com/user-attachments/assets/cad708cd-08d3-4b9e-af2c-b53e9a8d9f9e" />
