### PR TITLE
fix: update featured product carousel to navigate to pdp on image/title click

### DIFF
--- a/src/components/FeaturedCategories.tsx
+++ b/src/components/FeaturedCategories.tsx
@@ -12,15 +12,17 @@ interface FeaturedCategoriesProps {
 export const FeatureCategories: React.FC<FeaturedCategoriesProps> = ({ categories, onPress, onShopAllPress }) => {
   return (
     <View style={styles.outerContainer}>
-      <Text style={styles.titleText}>Featured Categories</Text>
+      <View style={styles.header}>
+        <Text style={styles.titleText}>Featured Categories</Text>
+        <TouchableOpacity onPress={onShopAllPress} style={styles.shopAllLink}>
+          <Text style={styles.shopAllText}>{'Shop All >'}</Text>
+        </TouchableOpacity>
+      </View>
       <View style={styles.container}>
         {categories.map(category => {
           return <FeaturedCategory onPress={onPress} category={category} key={category.slug} />
         })}
       </View>
-      <TouchableOpacity onPress={onShopAllPress} style={styles.shopAllLink}>
-        <Text style={styles.shopAllText}>{'Shop All Categories >'}</Text>
-      </TouchableOpacity>
     </View>
   );
 }

--- a/src/components/featuredProducts.tsx
+++ b/src/components/featuredProducts.tsx
@@ -4,8 +4,10 @@ import { styles } from "../styles/featuredProducts";
 
 interface FeaturedProductsProps {
   products: Product[];
-  addToCart: (product: Product) => void;
+  addToCart: (product: Product) => () => void;
+  navigateToProduct: (product: Product) => () => void;
   title: string;
+  cartFeaturedProducts?: boolean;
   containerStyle?: ViewStyle;
   titleStyle?: TextStyle;
   descStyle?: TextStyle;
@@ -19,11 +21,8 @@ interface ListItem {
 const defaultImage = require('../assets/images/default-product.webp');
 
 export const FeaturedProducts: React.FC<FeaturedProductsProps> = ({
-  products, addToCart, title, titleStyle, containerStyle, descStyle, boxStyle
+  products, addToCart, title, titleStyle, containerStyle, descStyle, boxStyle, navigateToProduct
 }) => {
-  const addItemToCart = (product: Product) => () => {
-    addToCart(product);
-  }
 
   const renderProduct = (item: ListItem): React.JSX.Element => {
     const product = item.item;
@@ -31,9 +30,11 @@ export const FeaturedProducts: React.FC<FeaturedProductsProps> = ({
 
     return (
       <View style={[styles.productBox, boxStyle]}>
-        <Image source={imageSrc} style={styles.image} resizeMode='cover' />
-        <Text style={[styles.productTitle, descStyle]} numberOfLines={2}>{product.title}</Text>
-        <TouchableOpacity onPress={addItemToCart(product)} style={styles.addToCartBtn}>
+        <TouchableOpacity onPress={navigateToProduct(product)} style={styles.navLink}>
+          <Image source={imageSrc} style={styles.image} resizeMode='cover' />
+          <Text style={[styles.productTitle, descStyle]} numberOfLines={2}>{product.title}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={addToCart(product)} style={styles.addToCartBtn}>
           <Text style={styles.addToCartText}>Add To Cart</Text>
         </TouchableOpacity>
       </View>

--- a/src/screens/CartScreen.tsx
+++ b/src/screens/CartScreen.tsx
@@ -60,9 +60,16 @@ export const CartScreen = () => {
     navigation.navigate('Home' as any);
   };
 
-  const addToCartPress = (product: Product) => {
+  const addToCartPress = (product: Product) => () => {
     dispatch(addToCart({product, qty: 1}));
-  }
+  };
+
+  const navigateToProduct = (product: Product) => () => {
+    navigation.navigate('Home' as any, {
+      screen: 'ProductDisplay', 
+      params: { productId: product.id, name: product.title }
+    });
+  };
 
   return (
     <ScrollView style={styles.main}>
@@ -91,6 +98,7 @@ export const CartScreen = () => {
         <FeaturedProducts
           title={'You Might Also Like'}
           addToCart={addToCartPress}
+          navigateToProduct={navigateToProduct}
           products={featuredProducts}
           titleStyle={{color: '#00008b'}}
           descStyle={{color: '#00008b'}}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -31,15 +31,19 @@ export const HomeScreen = () => {
 
   const onCategoryPress = (category: Category) => () => {
     navigation.navigate('ProductIndex', { category });
-  }
+  };
 
   const onShopAllPress = () => {
     navigation.navigate('Categories');
-  }
+  };
 
-  const addToCartPress = (product: Product) => {
+  const addToCartPress = (product: Product) => () => {
     dispatch(addToCart({product, qty: 1}));
-  }
+  };
+
+  const onProductNavigation = (product: Product) => () => {
+    navigation.navigate('ProductDisplay', { productId: product.id, name: product.title });
+  };
 
   return (
     <GradientWrapper>
@@ -62,6 +66,7 @@ export const HomeScreen = () => {
             title={'Featured Products'}
             addToCart={addToCartPress}
             products={featuredProducts}
+            navigateToProduct={onProductNavigation}
           />
         )}
       </ScrollView>

--- a/src/styles/FeaturedCategories.ts
+++ b/src/styles/FeaturedCategories.ts
@@ -4,12 +4,17 @@ export const styles = StyleSheet.create({
   outerContainer: {
     marginTop: 30,
     marginHorizontal: '5%',
-    width: '90%'
+    width: '90%',
+    marginBottom: 20
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 10
   },
   titleText: {
     fontSize: 20,
-    color: 'white',
-    marginBottom: 15
+    color: 'white'
   },
   container: {
     borderWidth: 2,
@@ -40,7 +45,7 @@ export const styles = StyleSheet.create({
     color: '#00008B'
   },
   shopAllLink: {
-    paddingVertical: 15
+
   },
   shopAllText: {
     fontSize: 20,

--- a/src/styles/featuredProducts.ts
+++ b/src/styles/featuredProducts.ts
@@ -24,6 +24,9 @@ export const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingHorizontal: 5
   },
+  navLink: {
+    alignItems: 'center'
+  },
   image: {
     height: 80,
     width: 80,


### PR DESCRIPTION
## Description

- move shop all categories link to top of section
- updates feature products on home and cart screens to navigate to pdp when clicking image or title

## Dev Notes

- need to type navigation when switching tabs, but still casting as `any` for now

## Testing

1. on home screen, click on image or title of product in featured products carousel
2. should navigate to pdp
3. on cart screen, click on image or title of product in featured products carousel
4. should switch tabs to Home and then navigate to pdp

