### PR TITLE
feat: add ATC modal to Home, Scan and Cart and style Scan modals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-native": "0.81.4",
         "react-native-gesture-handler": "^2.28.0",
         "react-native-linear-gradient": "^2.8.3",
+        "react-native-ratings": "^8.1.0",
         "react-native-reanimated": "^4.1.2",
         "react-native-reanimated-carousel": "^4.0.3",
         "react-native-safe-area-context": "^5.5.2",
@@ -9169,7 +9170,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -11096,6 +11096,19 @@
       "resolved": "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.8.3.tgz",
       "integrity": "sha512-KflAXZcEg54PXkLyflaSZQ3PJp4uC4whM7nT/Uot9m0e/qxFV3p6uor1983D1YOBJbJN7rrWdqIjq0T42jOJyA==",
       "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-ratings": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-8.1.0.tgz",
+      "integrity": "sha512-+QOJ4G3NjVkI1D+tk4EGx1dCvVfbD2nQdkrj9cXrcAoEiwmbep4z4bZbCKmWMpQ5h2dqbxABU8/eBnbDmvAc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-native": "0.81.4",
     "react-native-gesture-handler": "^2.28.0",
     "react-native-linear-gradient": "^2.8.3",
+    "react-native-ratings": "^8.1.0",
     "react-native-reanimated": "^4.1.2",
     "react-native-reanimated-carousel": "^4.0.3",
     "react-native-safe-area-context": "^5.5.2",

--- a/src/components/ATCModal.tsx
+++ b/src/components/ATCModal.tsx
@@ -1,0 +1,27 @@
+import { Image, TouchableOpacity, Text, View } from 'react-native';
+import { Product } from "../types/product";
+import { styles } from '../styles/ATCModal';
+
+interface ATCModalProps {
+  product?: Product;
+  onClose: () => void;
+}
+
+export const ATCModal: React.FC<ATCModalProps> = ({ product, onClose }) => {
+  return (
+    <View style={styles.modalBackdrop}>
+      <View style={styles.addedToCartModal}>
+        <Text style={styles.addedToCartModalText}>Item added to cart!</Text>
+        {!!product?.thumbnail && (
+          <Image source={{ uri: product.thumbnail }} resizeMode='cover' style={styles.modalImage} />
+        )}
+        {!!product?.title && (
+          <Text numberOfLines={2} style={styles.modalItemTitle}>{product.title}</Text>
+        )}
+        <TouchableOpacity onPress={onClose} style={styles.closeModalBtn}>
+          <Text style={styles.closeModalBtnText}>Close</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,37 @@
+import { View, StyleSheet } from 'react-native';
+
+interface ModalProps {
+  content: React.ReactNode;
+}
+
+const styles = StyleSheet.create({
+  modalBackdrop: {
+    zIndex: 5,
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  modalContent: {
+    zIndex: 6,
+    position: 'absolute',
+    marginTop: '30%',
+    marginHorizontal: '20%',
+    width: '60%',
+    backgroundColor: '#fff',
+    padding: 20,
+    borderRadius: 20,
+    justifyContent: 'space-around',
+    alignItems: 'center'
+  },
+});
+
+export const Modal: React.FC<ModalProps> = ({ content }) => {
+  return (
+    <View style={styles.modalBackdrop}>
+      <View style={styles.modalContent}>
+        {content}
+      </View>
+    </View>
+  );
+}

--- a/src/screens/CartScreen.tsx
+++ b/src/screens/CartScreen.tsx
@@ -1,5 +1,5 @@
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -16,6 +16,7 @@ import { styles } from '../styles/Cart';
 import { calculateCartTotal } from '../lib/helpers';
 import { CartStackParamList } from '../stacks/CartStack';
 import { FeaturedProducts } from '../components/featuredProducts';
+import { ATCModal } from '../components/ATCModal';
 
 export const CartScreen = () => {
   const dispatch = useAppDispatch();
@@ -23,6 +24,7 @@ export const CartScreen = () => {
   const items = useAppSelector(state => state.cartData.items);
   const featuredProducts = useAppSelector((state) => state.storeData.cartProducts);
   const navigation = useNavigation<NativeStackNavigationProp<CartStackParamList>>();
+  const [productAddedToCart, setProductAddedToCart] = useState<Product | null>(null);
 
   useEffect(() => {
     navigation.getParent()?.setOptions({
@@ -62,7 +64,12 @@ export const CartScreen = () => {
 
   const addToCartPress = (product: Product) => () => {
     dispatch(addToCart({product, qty: 1}));
+    setProductAddedToCart(product);
   };
+
+  const closeATCModal = () => {
+    setProductAddedToCart(null);
+  }
 
   const navigateToProduct = (product: Product) => () => {
     navigation.navigate('Home' as any, {
@@ -104,6 +111,9 @@ export const CartScreen = () => {
           descStyle={{color: '#00008b'}}
           boxStyle={{borderColor: '#00008b'}}
         />
+      )}
+      {!!productAddedToCart && (
+        <ATCModal onClose={closeATCModal} product={productAddedToCart} />
       )}
     </ScrollView>
   );

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import { ActivityIndicator, Image, ScrollView, Text, View } from 'react-native';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { GradientWrapper } from '../components/GradientWrapper';
 import { HomeStyles } from '../styles/HomeStyles';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
@@ -13,6 +13,7 @@ import { HomeStackParamList } from '../stacks/HomeStack';
 import { FeaturedProducts } from '../components/featuredProducts';
 import { addToCart } from '../reducers/cartData';
 import { Product } from '../types/product';
+import { ATCModal } from '../components/ATCModal';
 
 const titleBackground = require('../assets/images/home-title.jpeg');
 
@@ -21,6 +22,7 @@ export const HomeScreen = () => {
   const featuredCategories = useAppSelector((state) => state.storeData.featuredCategories);
   const featuredProducts = useAppSelector((state) => state.storeData.featuredProducts);
   const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
+  const [ productAddedToCart, setProductAddedToCart ] = useState<Product | null>(null);
 
   useEffect(() => {
     if (!featuredCategories?.length) {
@@ -39,7 +41,12 @@ export const HomeScreen = () => {
 
   const addToCartPress = (product: Product) => () => {
     dispatch(addToCart({product, qty: 1}));
+    setProductAddedToCart(product);
   };
+
+  const closeATCModal = () => {
+    setProductAddedToCart(null);
+  }
 
   const onProductNavigation = (product: Product) => () => {
     navigation.navigate('ProductDisplay', { productId: product.id, name: product.title });
@@ -70,6 +77,9 @@ export const HomeScreen = () => {
           />
         )}
       </ScrollView>
+      {!!productAddedToCart && (
+        <ATCModal product={productAddedToCart} onClose={closeATCModal} />
+      )}
     </GradientWrapper>
   );
 }

--- a/src/screens/ProductDisplay.tsx
+++ b/src/screens/ProductDisplay.tsx
@@ -1,4 +1,4 @@
-import { ActivityIndicator, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Image, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { RouteProp } from '@react-navigation/native';
 import { useMemo, useState } from 'react';
 import { GradientWrapper } from '../components/GradientWrapper';
@@ -10,6 +10,7 @@ import { formatPDPDetails } from '../lib/helpers';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { addToCart } from '../reducers/cartData';
 import { ProductDetail } from '../types/product';
+import { ATCModal } from '../components/ATCModal';
 
 interface ProductDisplayProps {
   route?: RouteProp<{ params: { productId: string } }, 'params'>;
@@ -75,14 +76,8 @@ export const ProductDisplayScreen: React.FC<ProductDisplayProps> = ({ route }) =
         </ScrollView>
       )}
       {showAddedToCartModal && (
-        <View style={styles.addedToCartModal}>
-          <Text style={styles.addedToCartModalText}>Item added to cart!</Text>
-          <TouchableOpacity onPress={closeAddedToCartModal} style={styles.closeModalBtn}>
-            <Text style={styles.closeModalBtnText}>Close</Text>
-          </TouchableOpacity>
-        </View>
+        <ATCModal product={data} onClose={closeAddedToCartModal} />
       )}
-      {showAddedToCartModal && <View style={styles.modalBackdrop} />}
       {!isLoading && !!data && (
         <TouchableOpacity onPress={addProductToCart} style={styles.addToCartBtn}>
           <Text style={styles.addToCartText}>Add To Cart</Text>

--- a/src/styles/ATCModal.ts
+++ b/src/styles/ATCModal.ts
@@ -1,0 +1,51 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+    addedToCartModal: {
+    zIndex: 6,
+    position: 'absolute',
+    marginTop: '30%',
+    marginHorizontal: '20%',
+    width: '60%',
+    backgroundColor: '#fff',
+    padding: 20,
+    borderRadius: 20,
+    justifyContent: 'space-around',
+    alignItems: 'center'
+  },
+  modalImage: {
+    height: 100,
+    width: 100,
+    marginTop: 20,
+    marginBottom: 10
+  },
+  modalItemTitle: {
+    fontSize: 18,
+    textAlign: 'center',
+    marginBottom: 10,
+    fontWeight: 'bold'
+  },
+  addedToCartModalText: {
+    fontSize: 24,
+    textAlign: 'center',
+    fontWeight: 'bold'
+  },
+  closeModalBtn: {
+    width: '100%',
+    backgroundColor: '#00008B',
+    borderRadius: 5
+  },
+  closeModalBtnText: {
+    color: '#fff',
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10
+  },
+  modalBackdrop: {
+    zIndex: 5,
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  }
+});

--- a/src/styles/ProductDisplay.ts
+++ b/src/styles/ProductDisplay.ts
@@ -83,41 +83,5 @@ export const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 24,
     textAlign: 'center'
-  },
-  addedToCartModal: {
-    zIndex: 6,
-    position: 'absolute',
-    marginTop: '30%',
-    marginHorizontal: '20%',
-    width: '60%',
-    height: 200,
-    backgroundColor: '#fff',
-    padding: 20,
-    borderRadius: 20,
-    justifyContent: 'space-around'
-  },
-  addedToCartModalText: {
-    fontSize: 24,
-    textAlign: 'center',
-    fontWeight: 'bold'
-  },
-  closeModalBtn: {
-    width: '100%',
-    backgroundColor: '#00008B',
-    borderRadius: 5
-  },
-  closeModalBtnText: {
-    color: '#fff',
-    fontSize: 20,
-    textAlign: 'center',
-    margin: 10
-  },
-  modalBackdrop: {
-    zIndex: 5,
-    position: 'absolute',
-    width: '100%',
-    height: '100%',
-    backgroundColor: '#000',
-    opacity: 0.5
   }
 });

--- a/src/styles/Scan.ts
+++ b/src/styles/Scan.ts
@@ -33,6 +33,20 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     textAlign: 'center'
   },
+  modalBox: {
+    alignItems: 'center',
+    height: 330
+  },
+  activityArea: {
+    height: 200,
+    justifyContent: 'center'
+  },
+  errorBox: {
+    justifyContent: 'space-around'
+  },
+  errorText: {
+    marginVertical: 40
+  },
   productModal: {
     zIndex: 6,
     position: 'absolute',
@@ -50,8 +64,20 @@ export const styles = StyleSheet.create({
     textAlign: 'center',
     fontWeight: 'bold'
   },
+  productImage: {
+    height: 100,
+    width: 100,
+    marginTop: 10,
+    marginBottom: 10
+  },
+  atcProductModalBtn: {
+    width: 150,
+    backgroundColor: '#00008B',
+    borderRadius: 5,
+    marginBottom: 20
+  },
   closeProductModalBtn: {
-   width: '100%',
+    width: 150,
     backgroundColor: '#00008B',
     borderRadius: 5
   },


### PR DESCRIPTION
## Description

- adds an ATC modal component based on PDP modal
- adds ATC modal to Home, Scan and Cart screen
- adds a generic modal component
- updates styling for Scan modals

## Testing

(test barcodes here https://github.com/bfhcodehacker/mock-store/pull/13)

1. add item to cart on PDP
2. should see item added to cart modal with image and product title
3. repeat on Home and Cart screens
4. test Scanning item and adding to cart in Scan screen
5. should see formatted modals
6. test error modal on scan as well


## Screenshots

<img width="390" height="860" alt="Pasted image" src="https://github.com/user-attachments/assets/bada7edb-3bbb-444c-8a65-cf8d8b73680e" />

